### PR TITLE
Add interval input parameter to Alchemy price tools

### DIFF
--- a/alphaswarm/services/alchemy/alchemy_client.py
+++ b/alphaswarm/services/alchemy/alchemy_client.py
@@ -121,11 +121,3 @@ class AlchemyClient:
         }
         response = self._make_request(self.ENDPOINT_TOKENS_HISTORICAL, data)
         return HistoricalPriceByAddress(**response)
-
-    @staticmethod
-    def interval_from_history(history_in_days: int) -> str:
-        if history_in_days <= 7:
-            return "5m"
-        if history_in_days <= 30:
-            return "1h"
-        return "1d"

--- a/alphaswarm/tools/alchemy/alchemy_price_history.py
+++ b/alphaswarm/tools/alchemy/alchemy_price_history.py
@@ -13,9 +13,14 @@ class AlchemyPriceHistoryBySymbol(Tool):
             "type": "string",
             "description": "Symbol/Name of the token to retrieve price history for",
         },
+        "interval": {
+            "type": "string",
+            "description": "Time interval between data points.",
+            "enum": ["5m", "1h", "1d"],
+        },
         "history": {
             "type": "integer",
-            "description": "Number of days to look back price history for",
+            "description": "Number of days to look back price history for. Max history for each interval: (5m, 7d), (1h, 30d), (1d, 365d).",
             "gt": 0,
             "lte": 365,
         },
@@ -26,10 +31,9 @@ class AlchemyPriceHistoryBySymbol(Tool):
         super().__init__()
         self.client = alchemy_client or AlchemyClient()
 
-    def forward(self, symbol: str, history: int) -> HistoricalPriceBySymbol:
+    def forward(self, symbol: str, interval: str, history: int) -> HistoricalPriceBySymbol:
         end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(days=history)
-        interval = self.client.interval_from_history(history)
         return self.client.get_historical_prices_by_symbol(symbol, start_time, end_time, interval)
 
 
@@ -46,9 +50,14 @@ class AlchemyPriceHistoryByAddress(Tool):
             "description": "Name of the network hosting the token",
             "enum": NETWORKS,
         },
+        "interval": {
+            "type": "string",
+            "description": "Time interval between data points.",
+            "enum": ["5m", "1h", "1d"],
+        },
         "history": {
             "type": "integer",
-            "description": "Number of days to look back price history for",
+            "description": "Number of days to look back price history for. Max history for each interval: (5m, 7d), (1h, 30d), (1d, 365d).",
             "gt": 0,
             "lte": 365,
         },
@@ -59,8 +68,7 @@ class AlchemyPriceHistoryByAddress(Tool):
         super().__init__()
         self.client = alchemy_client or AlchemyClient()
 
-    def forward(self, address: str, history: int, network: str) -> HistoricalPriceByAddress:
+    def forward(self, address: str, history: int, interval: str, network: str) -> HistoricalPriceByAddress:
         end_time = datetime.now(timezone.utc)
         start_time = end_time - timedelta(days=history)
-        interval = self.client.interval_from_history(history)
         return self.client.get_historical_prices_by_address(address, network, start_time, end_time, interval)

--- a/tests/integration/tools/alchemy/test_alchemy_price_history.py
+++ b/tests/integration/tools/alchemy/test_alchemy_price_history.py
@@ -4,7 +4,7 @@ from alphaswarm.tools.alchemy.alchemy_price_history import AlchemyPriceHistoryBy
 
 def test_get_price_history_by_symbol(alchemy_client: AlchemyClient) -> None:
     tool = AlchemyPriceHistoryBySymbol(alchemy_client)
-    result = tool.forward(symbol="USDC", history=1)
+    result = tool.forward(symbol="USDC", interval="5m", history=1)
 
     assert result.data[0].value > 0.1
 
@@ -12,5 +12,5 @@ def test_get_price_history_by_symbol(alchemy_client: AlchemyClient) -> None:
 def test_get_price_history_by_address(alchemy_client: AlchemyClient) -> None:
     tool = AlchemyPriceHistoryByAddress(alchemy_client)
     usdc_address = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    result = tool.forward(address=usdc_address, network="base-mainnet", history=1)
+    result = tool.forward(address=usdc_address, network="base-mainnet", interval="5m", history=1)
     assert result.data[0].value > 0.1


### PR DESCRIPTION
This PR adds `interval` input to the `AlchemyPriceHistoryByAddress` and `AlchemyPriceHistoryBySymbol` tools.

The agent should be able to select an interval for the price data based on the trading strategy which can have different measurement windows for price changes. 

I do not truncate the `history` to not exceed the max per interval because agent should know about these internal data manipulations.

The Alchemy API seems to provide descriptive error messages so I do not add any custom exceptions in the case history does exceed the max threshold: `Bad request: 5m interval is limited to 7 days or 2016 total data points.`

