### PR TITLE
Feature modify PriceTool with token address

### DIFF
--- a/alphaswarm/tools/price_tool.py
+++ b/alphaswarm/tools/price_tool.py
@@ -42,7 +42,7 @@ class PriceTool(Tool):
 
         Args:
             address: Contract address of the token
-            chain: Blockchain to use. Must be 'solana' for Solana tokens, 'base' for Base tokens, 'ethereum' for Ethereum tokens.
+            chain: Blockchain to use
         """
         try:
             # Normalize address to lowercase for consistent comparison

--- a/alphaswarm/tools/price_tool.py
+++ b/alphaswarm/tools/price_tool.py
@@ -22,7 +22,7 @@ class PriceTool(Tool):
         "chain": {
             "type": "string",
             "required": True,
-            "description": "Blockchain to use. Must be 'solana' for Solana tokens, 'base' for Base tokens, 'ethereum' for Ethereum tokens.",
+            "description": "Blockchain to use. For example, 'solana' for Solana tokens, 'base' for Base tokens, 'ethereum' for Ethereum tokens.",
         },
     }
     output_type = "string"

--- a/alphaswarm/tools/price_tool.py
+++ b/alphaswarm/tools/price_tool.py
@@ -11,17 +11,21 @@ class PriceTool(Tool):
     name = "price_tool"
     description = """
     Get the current price of a cryptocurrency in USD.
-    Supports major tokens like 'bitcoin', 'ethereum', etc.
     Returns price and 24h price change percentage.
     """
     inputs = {
-        "token_id": {
+        "address": {
             "type": "string",
             "required": True,
-            "description": "The CoinGecko token ID (e.g., 'bitcoin', 'ethereum')",
-        }
+            "description": "The contract address of the token",
+        },
+        "chain": {
+            "type": "string",
+            "required": True,
+            "description": "Blockchain to use. Must be 'solana' for Solana tokens, 'base' for Base tokens, 'ethereum' for Ethereum tokens.",
+        },
     }
-    output_type = "object"
+    output_type = "string"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -32,32 +36,36 @@ class PriceTool(Tool):
         """Cleanup the session when the tool is destroyed"""
         self.session.close()
 
-    def forward(self, token_id: str) -> str:
+    def forward(self, address: str, chain: str) -> str:
         """
         Fetch current price and 24h change for a given token
 
         Args:
-            token_id: CoinGecko token ID (e.g., 'bitcoin', 'ethereum')
+            address: Contract address of the token
+            chain: Blockchain to use. Must be 'solana' for Solana tokens, 'base' for Base tokens, 'ethereum' for Ethereum tokens.
         """
         try:
-            url = f"{self.base_url}/simple/price"
-            params = {"ids": token_id, "vs_currencies": "usd", "include_24hr_change": "true"}
+            # Normalize address to lowercase for consistent comparison
+            address = address.lower()
+
+            url = f"{self.base_url}/simple/token_price/{chain}"
+            params = {"contract_addresses": address, "vs_currencies": "usd", "include_24hr_change": "true"}
 
             response = self.session.get(url, params=params, timeout=10)
 
             if response.status_code != 200:
-                return f"Error: Could not fetch price for {token_id} (Status: {response.status_code})"
+                return f"Error: Could not fetch price for {address} (Status: {response.status_code})"
 
             data = response.json()
 
-            if token_id not in data:
-                return f"Error: Token '{token_id}' not found"
+            if address not in data:
+                return f"Error: Token with address '{address}' not found"
 
-            price = data[token_id]["usd"]
-            change_24h = data[token_id]["usd_24h_change"]
+            price = data[address]["usd"]
+            change_24h = data[address]["usd_24h_change"]
 
             timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
-            return f"[{timestamp}] {token_id.upper()}\n" f"Price: ${price:,.2f}\n" f"24h Change: {change_24h:+.2f}%"
+            return f"[{timestamp}] {address}\n" f"Price: ${price:,.2f}\n" f"24h Change: {change_24h:+.2f}%"
 
         except requests.RequestException as e:
             return f"Network error: {str(e)}"


### PR DESCRIPTION
Update `PriceTool` from CoinGecko to use token address instead of token id.