### PR TITLE
Feature improve tg msg parsing

### DIFF
--- a/alphaswarm/agent/clients/telegram_bot.py
+++ b/alphaswarm/agent/clients/telegram_bot.py
@@ -137,13 +137,13 @@ You can also just chat with me naturally!"""
         update = context.context
         if update.message is None:
             raise ValueError("missing message")
-        await update.message.reply_text(message.content, parse_mode="Markdown")
+        await update.message.reply_text(message.content)
 
     async def on_agent_error(self, context: Context[Update], error: ChatMessage) -> None:
         update = context.context
         if update.message is None:
             raise ValueError("missing message")
-        await update.message.reply_text(error.content, parse_mode="Markdown")
+        await update.message.reply_text(error.content)
 
     async def on_start(self) -> None:
         await self._start()

--- a/alphaswarm/agent/clients/telegram_bot.py
+++ b/alphaswarm/agent/clients/telegram_bot.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
+from typing import Any
 
 from telegram import Update
-from telegram._utils.defaultvalue import DEFAULT_NONE
-from telegram._utils.types import ODVInput
 from telegram.constants import ParseMode
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
@@ -34,10 +33,10 @@ class TelegramApp:
         await self._app.stop()
         await self._app.shutdown()
 
-    async def send_message(self, chat_id: int, *, message: str, parse_mode: ODVInput[str] = DEFAULT_NONE) -> None:
+    async def send_message(self, chat_id: int, message: str, **kwargs: Any) -> None:
         """Send a message to a specific chat"""
         try:
-            await self._app.bot.send_message(chat_id=chat_id, text=message, parse_mode=parse_mode)
+            await self._app.bot.send_message(chat_id=chat_id, text=message, **kwargs)
         except Exception as e:
             logger.error(f"Failed to send Telegram message: {e}")
             raise e

--- a/alphaswarm/agent/clients/telegram_bot.py
+++ b/alphaswarm/agent/clients/telegram_bot.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 
 from telegram import Update
+from telegram._utils.defaultvalue import DEFAULT_NONE
+from telegram._utils.types import ODVInput
 from telegram.constants import ParseMode
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
@@ -32,7 +34,7 @@ class TelegramApp:
         await self._app.stop()
         await self._app.shutdown()
 
-    async def send_message(self, chat_id: int, *, message: str, parse_mode: str = ParseMode.MARKDOWN) -> None:
+    async def send_message(self, chat_id: int, *, message: str, parse_mode: ODVInput[str] = DEFAULT_NONE) -> None:
         """Send a message to a specific chat"""
         try:
             await self._app.bot.send_message(chat_id=chat_id, text=message, parse_mode=parse_mode)

--- a/alphaswarm/tools/telegram/send_telegram_notification.py
+++ b/alphaswarm/tools/telegram/send_telegram_notification.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from alphaswarm.agent.clients.telegram_bot import TelegramApp
 from smolagents import Tool
+from telegram.constants import ParseMode
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,9 @@ class SendTelegramNotificationTool(Tool):
         message_to_send = self.format_alert_message(message=message, confidence=confidence, priority=priority)
 
         async def send_message() -> None:
-            await self._telegram_app.send_message(chat_id=self.chat_id, message=message_to_send, parse_mode="Markdown")
+            await self._telegram_app.send_message(
+                chat_id=self.chat_id, message=message_to_send, parse_mode=ParseMode.MARKDOWN
+            )
 
         self._loop.run_until_complete(send_message())
 

--- a/alphaswarm/tools/telegram/send_telegram_notification.py
+++ b/alphaswarm/tools/telegram/send_telegram_notification.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from alphaswarm.agent.clients.telegram_bot import TelegramApp
 from smolagents import Tool
+from telegram.constants import ParseMode
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,9 @@ class SendTelegramNotificationTool(Tool):
         message_to_send = self.format_alert_message(message=message, confidence=confidence, priority=priority)
 
         async def send_message() -> None:
-            await self._telegram_app.send_message(chat_id=self.chat_id, message=message_to_send)
+            await self._telegram_app.send_message(
+                chat_id=self.chat_id, message=message_to_send, parse_mode=ParseMode.MARKDOWN
+            )
 
         self._loop.run_until_complete(send_message())
 

--- a/alphaswarm/tools/telegram/send_telegram_notification.py
+++ b/alphaswarm/tools/telegram/send_telegram_notification.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from alphaswarm.agent.clients.telegram_bot import TelegramApp
 from smolagents import Tool
-from telegram.constants import ParseMode
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +45,7 @@ class SendTelegramNotificationTool(Tool):
         message_to_send = self.format_alert_message(message=message, confidence=confidence, priority=priority)
 
         async def send_message() -> None:
-            await self._telegram_app.send_message(
-                chat_id=self.chat_id, message=message_to_send, parse_mode=ParseMode.MARKDOWN
-            )
+            await self._telegram_app.send_message(chat_id=self.chat_id, message=message_to_send, parse_mode="Markdown")
 
         self._loop.run_until_complete(send_message())
 


### PR DESCRIPTION
The `telegram_bot` client has been assuming that all agent responses are parseable as markdown, despite there being no such instructions to the agent. This leads to parsing errors such as `Error processing message: Can't parse entities: can't find end of the entity starting at byte offset...` or unintended formatting of agent responses. 

The refactoring removes the constraint of markdown parsing for general agent responses, while keeping it for telegram commands such as `/help` and the `SendTelegramNotificationTool`.